### PR TITLE
Give Hammer Suit a unique name

### DIFF
--- a/smb3.asm
+++ b/smb3.asm
@@ -2419,7 +2419,7 @@ Tile_Mem:	.ds 6480	; $6000-$794F Space used to store the 16x16 "tiles" that make
 	; 3 = Leaf
 	; 4 = Frog
 	; 5 = Tanooki
-	; 6 = Hammer
+	; 6 = Hammer Suit
 	; 7 = Judgem's cloud
 	; 8 = P-Wing
 	; 9 = Star
@@ -2717,7 +2717,7 @@ CFIRE_LASER		= $15	; Laser fire
 	; 3 = Leaf
 	; 4 = Frog
 	; 5 = Tanooki
-	; 6 = Hammer
+	; 6 = Hammer Suit
 	; 7 = Judgem's cloud
 	; 8 = P-Wing
 	; 9 = Star


### PR DESCRIPTION
There were two items labelled "Hammer". Rename the one with the value 06 to Hammer Suit because that's what it is. The one with value 0B is the one that smashes rocks in the overworld.